### PR TITLE
Heroku launchable 

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: vendor/bin/heroku-php-apache2 public_html/

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "require": {
+        "php": "^7.2",
         "smarty/smarty": "^3.1"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "99bccada065081929698167137529f9f",
+    "content-hash": "acc3a794b6e65c42134af5aa54bd79cd",
     "packages": [
         {
             "name": "smarty/smarty",
@@ -66,6 +66,8 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": "^7.2"
+    },
     "platform-dev": []
 }


### PR DESCRIPTION
Heroku knows that this is a PHP project because the Repo has a composer.json file (Composer is the PHP Package manager)

A Procfile tells heroku to use Apache + PHP + a way to set the Document Root, just like in our MAMP application. 